### PR TITLE
Commenting to make the single char clear

### DIFF
--- a/admin/digilan-admin.php
+++ b/admin/digilan-admin.php
@@ -726,8 +726,8 @@ class DigilanTokenAdmin
             wp_redirect(self::getAdminUrl('form-settings'));
             exit();
         }
-        $current = $form_languages[$lang]['implemented'];
-        $form_languages[$lang]['implemented'] = !$current;
+        // flip implemented value
+        $form_languages[$lang]['implemented'] ^= $form_languages[$lang]['implemented'];
         update_option('digilan_token_form_languages', $form_languages);
     }
 


### PR DESCRIPTION
According to science `https://stackoverflow.com/questions/4603589/boolean-value-switch-invert`

```
Time to swap values 1 millon times:

$bool ^= 1 -> 0.2595 seconds
$bool = $bool!=true -> 0.2803 seconds
$bool = !$bool -> 0.2833 seconds
$bool = ($bool-1)*(-1) -> 0.3047 seconds
$bool = $bool?0:1 -> 0.3253 seconds
if -> 0.3589 seconds
switch -> 0.4387 seconds
$bool = abs($bool-1) -> 1.2211 seconds
```

mais c est surtout pour eviter un '$current' et un '!$current'