### PR TITLE
Revert "Commenting to make the single char clear"

### DIFF
--- a/admin/digilan-admin.php
+++ b/admin/digilan-admin.php
@@ -726,8 +726,8 @@ class DigilanTokenAdmin
             wp_redirect(self::getAdminUrl('form-settings'));
             exit();
         }
-        // flip implemented value
-        $form_languages[$lang]['implemented'] ^= $form_languages[$lang]['implemented'];
+        $current = $form_languages[$lang]['implemented'];
+        $form_languages[$lang]['implemented'] = !$current;
         update_option('digilan_token_form_languages', $form_languages);
     }
 

--- a/admin/digilan-admin.php
+++ b/admin/digilan-admin.php
@@ -726,8 +726,8 @@ class DigilanTokenAdmin
             wp_redirect(self::getAdminUrl('form-settings'));
             exit();
         }
-        $current = $form_languages[$lang]['implemented'];
-        $form_languages[$lang]['implemented'] = !$current;
+        // flip implemented value
+        $form_languages[$lang]['implemented'] ^= 1;
         update_option('digilan_token_form_languages', $form_languages);
     }
 


### PR DESCRIPTION
Reverts TimotheCity/digilan-token#2

Bad : `$x ^= $x` only swap from true to false, but never from false to true

XOR operator return 
- `false` if both values are `true` or both values are `false`
- `true` if both values are different

But `$x` equals itself, then the result will always be `false`, which means no revert.
